### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ callbacks.
 Documentation
 -------------
 
-| Visit `classjs-plugins.rtfd.org <http://classjs-plugins.rtfd.org>`_ for a full documentation or go to the `demo page <http://divio.github.io/classjs-plugins/>`_ to view the examples.
+| Visit `classjs-plugins.rtfd.org <https://classjs-plugins.readthedocs.io>`_ for a full documentation or go to the `demo page <http://divio.github.io/classjs-plugins/>`_ to view the examples.
 | Please use github to report bugs or feature requests. Include a `jsfiddle <http://jsfiddle.net>`_ or equivalent example whenever possible.
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
